### PR TITLE
Added BUFFERED/ENROUTE DLR support with registered_delivery field che…

### DIFF
--- a/core/slee/services/mtsbb/src/main/java/org/mobicents/smsc/slee/services/mt/MtCommonSbb.java
+++ b/core/slee/services/mtsbb/src/main/java/org/mobicents/smsc/slee/services/mt/MtCommonSbb.java
@@ -598,6 +598,10 @@ public abstract class MtCommonSbb implements Sbb, ReportSMDeliveryStatusInterfac
 			}
 		}
 
+		if ( errorAction != ErrorAction.permanentFailure &&
+						!smscPropertiesManagement.getReceiptsDisabling() ) {
+				doIntermediateReceipts(smsSet, pers, currentMsgNum, lstFailured);
+		}
         for (Sms sms : lstFailured) {
             CdrGenerator.generateCdr(sms, (isImsiVlrReject ? CdrGenerator.CDR_FAILED_IMSI : CdrGenerator.CDR_FAILED), reason,
                     smscPropertiesManagement.getGenerateReceiptCdr(),
@@ -728,6 +732,65 @@ public abstract class MtCommonSbb implements Sbb, ReportSMDeliveryStatusInterfac
             this.setupReportSMDeliveryStatusRequest(smsSet.getDestAddr(), smsSet.getDestAddrTon(), smsSet.getDestAddrNpi(), smDeliveryOutcome,
                     smsSet.getTargetId(), smsSet.getNetworkId());
 		}
+	}
+
+	private void doIntermediateReceipts(SmsSet smsSet, PersistenceRAInterface pers, long currentMsgNum, ArrayList<Sms> lstFailured) {
+		TargetAddress lock;
+		long smsCnt = smsSet.getSmsCount();
+		for (long i1 = currentMsgNum; i1 < smsCnt; i1++) {
+            Sms sms = smsSet.getSms(i1);
+            int registeredDelivery = sms.getRegisteredDelivery();
+            if (MessageUtil.isReceiptOnFailure(registeredDelivery) && lstFailured.indexOf(sms) == -1) {
+                TargetAddress ta = new TargetAddress(sms.getSourceAddrTon(), sms.getSourceAddrNpi(), sms.getSourceAddr(), smsSet.getNetworkId());
+                lock = SmsSetCache.getInstance().addSmsSet(ta);
+                try {
+                    synchronized (lock) {
+                        try {
+                            Sms receipt;
+                            if (smscPropertiesManagement.getDatabaseType() == DatabaseType.Cassandra_1) {
+                                receipt = MessageUtil.createReceiptSms(sms, false);
+                                SmsSet backSmsSet = pers.obtainSmsSet(ta);
+                                receipt.setSmsSet(backSmsSet);
+                                receipt.setStored(true);
+                                pers.createLiveSms(receipt);
+                                pers.setNewMessageScheduled(receipt.getSmsSet(),
+                                        MessageUtil.computeDueDate(MessageUtil.computeFirstDueDelay(smscPropertiesManagement.getFirstDueDelay())));
+                            } else {
+                                receipt = MessageUtil.createReceiptSms(sms, false, ta, smscPropertiesManagement.getOrigNetworkIdForReceipts(),null,true);
+                                boolean storeAndForwMode = MessageUtil.isStoreAndForward(sms);
+                                if (!storeAndForwMode) {
+                                    try {
+                                        this.scheduler.injectSmsOnFly(receipt.getSmsSet(), true);
+                                    } catch (Exception e) {
+                                        this.logger.severe("Exception when runnung injectSmsOnFly() for receipt in onDeliveryError(): " + e.getMessage(), e);
+                                    }
+                                } else {
+                                    if (smscPropertiesManagement.getStoreAndForwordMode() == StoreAndForwordMode.fast) {
+                                        try {
+                                            receipt.setStoringAfterFailure(true);
+                                            this.scheduler.injectSmsOnFly(receipt.getSmsSet(), true);
+                                        } catch (Exception e) {
+                                            this.logger
+                                                    .severe("Exception when runnung injectSmsOnFly() for receipt in onDeliveryError(): " + e.getMessage(), e);
+                                        }
+                                    } else {
+                                        receipt.setStored(true);
+                                        this.scheduler.setDestCluster(receipt.getSmsSet());
+                                        pers.c2_scheduleMessage_ReschedDueSlot(receipt,
+                                                smscPropertiesManagement.getStoreAndForwordMode() == StoreAndForwordMode.fast, true);
+                                    }
+                                }
+                            }
+                            this.logger.info("Adding an error receipt: source=" + receipt.getSourceAddr() + ", dest=" + receipt.getSmsSet().getDestAddr());
+                        } catch (PersistenceException e) {
+                            this.logger.severe("PersistenceException when freeSmsSetFailured(SmsSet smsSet) - adding delivery receipt" + e.getMessage(), e);
+                        }
+                    }
+                } finally {
+                    SmsSetCache.getInstance().removeSmsSet(lock);
+                }
+            }
+        }
 	}
 
     protected void onImsiDrop(Sms sms, String imsi, ISDNAddressString nnn) {

--- a/core/slee/services/rxsmppserversbb/src/main/java/org/mobicents/smsc/slee/services/smpp/server/rx/RxSmppServerSbb.java
+++ b/core/slee/services/rxsmppserversbb/src/main/java/org/mobicents/smsc/slee/services/smpp/server/rx/RxSmppServerSbb.java
@@ -633,6 +633,12 @@ public abstract class RxSmppServerSbb implements Sbb {
 			}
 		}
 
+		// check if we need to send temporary delivery reports
+		if ( errorAction != ErrorAction.permanentFailure &&
+				!smscPropertiesManagement.getReceiptsDisabling() ) {
+			doIntermediateReceipts(smsSet, pers, currentMsgNum, lstFailured);
+		}
+
 		for (Sms sms : lstFailured) {
             CdrGenerator.generateCdr(sms, CdrGenerator.CDR_FAILED_ESME, reason, smscPropertiesManagement.getGenerateReceiptCdr(),
                     MessageUtil.isNeedWriteArchiveMessage(sms, smscPropertiesManagement.getGenerateCdr()));
@@ -744,6 +750,65 @@ public abstract class RxSmppServerSbb implements Sbb {
                     SmsSetCache.getInstance().removeSmsSet(lock);
                 }
             }
+		}
+	}
+
+	private void doIntermediateReceipts(SmsSet smsSet, PersistenceRAInterface pers, long currentMsgNum, ArrayList<Sms> lstFailured) {
+		TargetAddress lock;
+		long smsCnt = smsSet.getSmsCount();
+		for (long i1 = currentMsgNum; i1 < smsCnt; i1++) {
+			Sms sms = smsSet.getSms(i1);
+			int registeredDelivery = sms.getRegisteredDelivery();
+			if (MessageUtil.isReceiptIntermediate(registeredDelivery) && lstFailured.indexOf(sms) == -1) {
+				TargetAddress ta = new TargetAddress(sms.getSourceAddrTon(), sms.getSourceAddrNpi(), sms.getSourceAddr(), smsSet.getNetworkId());
+				lock = SmsSetCache.getInstance().addSmsSet(ta);
+				try {
+					synchronized (lock) {
+						try {
+							Sms receipt;
+							if (smscPropertiesManagement.getDatabaseType() == DatabaseType.Cassandra_1) {
+								receipt = MessageUtil.createReceiptSms(sms, false);
+								SmsSet backSmsSet = pers.obtainSmsSet(ta);
+								receipt.setSmsSet(backSmsSet);
+								receipt.setStored(true);
+								pers.createLiveSms(receipt);
+								pers.setNewMessageScheduled(receipt.getSmsSet(),
+										MessageUtil.computeDueDate(MessageUtil.computeFirstDueDelay(smscPropertiesManagement.getFirstDueDelay())));
+							} else {
+								receipt = MessageUtil.createReceiptSms(sms, false, ta, smscPropertiesManagement.getOrigNetworkIdForReceipts(),null,true);
+								boolean storeAndForwMode = MessageUtil.isStoreAndForward(sms);
+								if (!storeAndForwMode) {
+									try {
+										this.scheduler.injectSmsOnFly(receipt.getSmsSet(), true);
+									} catch (Exception e) {
+										this.logger.severe("Exception when runnung injectSmsOnFly() for receipt in onDeliveryError(): " + e.getMessage(), e);
+									}
+								} else {
+									if (smscPropertiesManagement.getStoreAndForwordMode() == StoreAndForwordMode.fast) {
+										try {
+											receipt.setStoringAfterFailure(true);
+											this.scheduler.injectSmsOnFly(receipt.getSmsSet(), true);
+										} catch (Exception e) {
+											this.logger
+													.severe("Exception when runnung injectSmsOnFly() for receipt in onDeliveryError(): " + e.getMessage(), e);
+										}
+									} else {
+										receipt.setStored(true);
+										this.scheduler.setDestCluster(receipt.getSmsSet());
+										pers.c2_scheduleMessage_ReschedDueSlot(receipt,
+												smscPropertiesManagement.getStoreAndForwordMode() == StoreAndForwordMode.fast, true);
+									}
+								}
+							}
+							this.logger.info("Adding an error receipt: source=" + receipt.getSourceAddr() + ", dest=" + receipt.getSmsSet().getDestAddr());
+						} catch (PersistenceException e) {
+							this.logger.severe("PersistenceException when freeSmsSetFailured(SmsSet smsSet) - adding delivery receipt" + e.getMessage(), e);
+						}
+					}
+				} finally {
+					SmsSetCache.getInstance().removeSmsSet(lock);
+				}
+			}
 		}
 	}
 

--- a/core/smsc-common-library/src/main/java/org/mobicents/smsc/library/MessageUtil.java
+++ b/core/smsc-common-library/src/main/java/org/mobicents/smsc/library/MessageUtil.java
@@ -472,6 +472,7 @@ public class MessageUtil {
     private static final String DELIVERY_ACK_TEXT = " text:";
     private static final String DELIVERY_ACK_STATE_DELIVERED = "DELIVRD";
     private static final String DELIVERY_ACK_STATE_UNDELIVERABLE = "UNDELIV";
+    private static final String DELIVERY_ACK_STATE_ENROUTE = "ENROUTE";
     public static final byte ESME_DELIVERY_ACK = 0x04;
     private static final SimpleDateFormat DELIVERY_ACK_DATE_FORMAT = new SimpleDateFormat("yyMMddHHmm");
 
@@ -491,13 +492,26 @@ public class MessageUtil {
             return false;
     }
 
-    public static Sms createReceiptSms(Sms sms, boolean delivered, TargetAddress ta, boolean origNetworkIdForReceipts) {
-        return createReceiptSms(sms, delivered, ta, origNetworkIdForReceipts, null);
+    public static boolean isReceiptIntermediate(int registeredDelivery) {
+            int code = registeredDelivery & 0x10;
+            if (code == 16 )
+                    return true;
+            else
+                    return false;
     }
 
     public static Sms createReceiptSms(Sms sms, boolean delivered, TargetAddress ta, boolean origNetworkIdForReceipts,
-            String extraString) {
-        Sms receipt = createReceiptSms(sms, delivered, extraString);
+                    String extraString) {
+            return createReceiptSms(sms, delivered, ta, origNetworkIdForReceipts, extraString, false);
+    }
+
+    public static Sms createReceiptSms(Sms sms, boolean delivered, TargetAddress ta, boolean origNetworkIdForReceipts) {
+        return createReceiptSms(sms, delivered, ta, origNetworkIdForReceipts, null, false);
+    }
+
+    public static Sms createReceiptSms(Sms sms, boolean delivered, TargetAddress ta, boolean origNetworkIdForReceipts,
+            String extraString, boolean tempFailure) {
+        Sms receipt = createReceiptSms(sms, delivered, extraString, tempFailure);
         SmsSet backSmsSet = new SmsSet();
         backSmsSet.setDestAddr(ta.getAddr());
         backSmsSet.setDestAddrNpi(ta.getAddrNpi());
@@ -516,6 +530,10 @@ public class MessageUtil {
     }
 
     public static Sms createReceiptSms(Sms sms, boolean delivered, String extraString) {
+            return createReceiptSms(sms, delivered, extraString, false);
+    }
+
+    public static Sms createReceiptSms(Sms sms, boolean delivered, String extraString, boolean tempFailure) {
         Sms receipt = new Sms();
         receipt.setDbId(UUID.randomUUID());
         receipt.setSourceAddr(sms.getSmsSet().getDestAddr());
@@ -547,7 +565,11 @@ public class MessageUtil {
             sb.append(DELIVERY_ACK_ERR);
             sb.append("000");
         } else {
-            sb.append(DELIVERY_ACK_STATE_UNDELIVERABLE);
+                if(!tempFailure) {
+                        sb.append(DELIVERY_ACK_STATE_UNDELIVERABLE);
+                } else {
+                        sb.append(DELIVERY_ACK_STATE_ENROUTE);
+                }
             sb.append(DELIVERY_ACK_ERR);
             ErrorCode errorCode = sms.getSmsSet().getStatus();
             sb.append(errorCode != null ? errorCode.getCodeText() : "null");

--- a/tools/smpp-simulator/simulator/src/main/java/org/mobicents/smsc/tools/smppsimulator/SmppSimulatorParameters.java
+++ b/tools/smpp-simulator/simulator/src/main/java/org/mobicents/smsc/tools/smppsimulator/SmppSimulatorParameters.java
@@ -388,7 +388,7 @@ public class SmppSimulatorParameters {
     }
 
     public enum MCDeliveryReceipt {
-        No(0), onSuccessOrFailure(1), onFailure(2), onSuccess(3);
+        No(0), onSuccessOrFailure(1), onFailure(2), onSuccess(3), onSuccessTempOrPermanentFailure(17);
 
         private int code;
 


### PR DESCRIPTION
Intermediate ENROUTE dlr support. When registered_delivery bit 4 is set for intermediate delivery in SMPP SUBMIT_SM, the SMSC sends out receipt SMS (DLR) for temporary failures.
Tested with SMSC for SS7 routing SMS routing. 