### PR TITLE
fix #144

### DIFF
--- a/core/slee/services/txhttpserversbb/src/main/java/org/mobicents/smsc/slee/services/http/server/tx/data/HttpSendMessageIncomingData.java
+++ b/core/slee/services/txhttpserversbb/src/main/java/org/mobicents/smsc/slee/services/http/server/tx/data/HttpSendMessageIncomingData.java
@@ -66,9 +66,10 @@ public class HttpSendMessageIncomingData extends BaseIncomingData {
 
     private TON senderTon;
     private NPI senderNpi;
+    private byte[] udh;
 
     public HttpSendMessageIncomingData(String userId, String password, String msg, String formatParam, String smscEncodingStr, String messageBodyEncodingStr,
-                                       String sender, String senderTon, String senderNpi, String[] to, SmscPropertiesManagement smscPropertiesManagement, HttpUsersManagement httpUsersManagement) throws HttpApiException, UnauthorizedException {
+                                       String sender, String senderTon, String senderNpi, String[] to, SmscPropertiesManagement smscPropertiesManagement, HttpUsersManagement httpUsersManagement, String udhStr) throws HttpApiException, UnauthorizedException {
         super(userId, password, formatParam, httpUsersManagement);
 
         if (isEmptyOrNull(msg)) {
@@ -130,6 +131,10 @@ public class HttpSendMessageIncomingData extends BaseIncomingData {
                     break;
             }
         }
+
+		if (udhStr != null) {
+			this.udh = udhToByte(udhStr);
+		}
 
         this.sender = sender;
         this.msg = decodeMessage(msg, getMessageBodyEncoding());
@@ -233,6 +238,12 @@ public class HttpSendMessageIncomingData extends BaseIncomingData {
         return notValidDestinationNumbers;
     }
 
+	private byte[] udhToByte(String udhDecoded) {
+		byte[] udhDec = udhDecoded.getBytes(Charset.forName("UTF-8"));
+
+		return udhDec;
+	}
+
     public List<String> getDestAddresses() {
         return destAddresses;
     }
@@ -265,6 +276,19 @@ public class HttpSendMessageIncomingData extends BaseIncomingData {
         return this.msg;
     }
 
+    public byte[] getUdh() {
+        return udh;
+    }
+
+    public String udhToString (byte[] udhs) {
+        StringBuilder udhtoString = new StringBuilder();
+        for (byte b : udhs) {
+            udhtoString.append(b);
+            udhtoString.append(":");
+        }
+        return udhtoString.toString();
+    }
+
     @Override
     public String toString() {
         return "HttpSendMessageIncomingData{" +
@@ -278,6 +302,7 @@ public class HttpSendMessageIncomingData extends BaseIncomingData {
                 ", senderTon='" + senderTon + '\'' +
                 ", senderNpi='" + senderNpi + '\'' +
                 ", destAddresses=" + destAddresses + '\'' +
+                ", udh=" + udhToString(udh) + '\'' +
                 '}';
     }
 }

--- a/core/slee/services/txhttpserversbb/src/main/java/org/mobicents/smsc/slee/services/http/server/tx/enums/RequestParameter.java
+++ b/core/slee/services/txhttpserversbb/src/main/java/org/mobicents/smsc/slee/services/http/server/tx/enums/RequestParameter.java
@@ -15,7 +15,8 @@ public enum RequestParameter {
     SMSC_ENCODING("smscEncoding"),
     MESSAGE_BODY_ENCODING("messageBodyEncoding"),
     SENDER_TON("senderTon"),
-    SENDER_NPI("senderNpi");
+    SENDER_NPI("senderNpi"),
+    UDH("udh");
 
     private String name;
 

--- a/core/slee/services/txhttpserversbb/src/test/java/org/mobicents/smsc/slee/services/http/server/tx/AutodecodingTest.java
+++ b/core/slee/services/txhttpserversbb/src/test/java/org/mobicents/smsc/slee/services/http/server/tx/AutodecodingTest.java
@@ -24,7 +24,7 @@ public class AutodecodingTest {
         httpUsersManagement.createHttpUser("userId", "password");
 
         HttpSendMessageIncomingData idata = new HttpSendMessageIncomingData("userId", "password", "msg", null, null, null,
-                "wwwwww", null, null, new String[] { "6666" }, smscPropertiesManagement, httpUsersManagement);
+                "wwwwww", null, null, new String[] { "6666" }, smscPropertiesManagement, httpUsersManagement,"");
 
         assertEquals(idata.getSender(), "wwwwww");
         assertEquals(idata.getSenderTon(), org.mobicents.smsc.slee.services.http.server.tx.enums.TON.ALFANUMERIC);
@@ -33,7 +33,7 @@ public class AutodecodingTest {
 
         // international
         idata = new HttpSendMessageIncomingData("userId", "password", "msg", null, null, null, "+33334444", null, null,
-                new String[] { "6666" }, smscPropertiesManagement, httpUsersManagement);
+                new String[] { "6666" }, smscPropertiesManagement, httpUsersManagement, "");
 
         assertEquals(idata.getSender(), "33334444");
         assertEquals(idata.getSenderTon(), org.mobicents.smsc.slee.services.http.server.tx.enums.TON.INTERNATIONAL);
@@ -42,7 +42,7 @@ public class AutodecodingTest {
 
         // national
         idata = new HttpSendMessageIncomingData("userId", "password", "www", null, null, null, "33334444", null, null,
-                new String[] { "6666" }, smscPropertiesManagement, httpUsersManagement);
+                new String[] { "6666" }, smscPropertiesManagement, httpUsersManagement, "");
 
         assertEquals(idata.getSender(), "33334444");
         assertEquals(idata.getSenderTon(), org.mobicents.smsc.slee.services.http.server.tx.enums.TON.NATIONAL);
@@ -64,7 +64,7 @@ public class AutodecodingTest {
         httpUsersManagement.createHttpUser("userId", "password");
 
         HttpSendMessageIncomingData idata = new HttpSendMessageIncomingData("userId", "password", "msg", null, null, null,
-                "wwwwww", null, null, new String[] { "6666" }, smscPropertiesManagement, httpUsersManagement);
+                "wwwwww", null, null, new String[] { "6666" }, smscPropertiesManagement, httpUsersManagement,"");
 
         assertEquals(idata.getSender(), "wwwwww");
         assertEquals(idata.getSenderTon(), org.mobicents.smsc.slee.services.http.server.tx.enums.TON.ALFANUMERIC);
@@ -73,7 +73,7 @@ public class AutodecodingTest {
 
         // international
         idata = new HttpSendMessageIncomingData("userId", "password", "msg", null, null, null, "33334444", null, null,
-                new String[] { "6666" }, smscPropertiesManagement, httpUsersManagement);
+                new String[] { "6666" }, smscPropertiesManagement, httpUsersManagement,"");
 
         assertEquals(idata.getSender(), "33334444");
         assertEquals(idata.getSenderTon(), org.mobicents.smsc.slee.services.http.server.tx.enums.TON.INTERNATIONAL);

--- a/docs/adminguide/sources-asciidoc/src/main/asciidoc/Chapter-Configuring.adoc
+++ b/docs/adminguide/sources-asciidoc/src/main/asciidoc/Chapter-Configuring.adoc
@@ -1371,6 +1371,7 @@ are GET and POST. Request URL must have “sendSms” context and contain all of
 | messageBodyEncoding | Values can be "UTF8" or "UTF16". If parameter is not provided then value depends on "smscEncoding" parameter and it is taken from SMSC properties . Default value is "UTF8". This parameter affects data encoding of a message body at HTTP interface.
 | senderTon | TON value for a source address (if missed then <<_httpdefaultsourceton>> value will be used)
 | senderNpi | NPI value for a source address (if missed then <<_httpdefaultsourcenpi>> value will be used)
+| udh | Optional User Data Header (UDH) part of the message. Must be URL encoded (if missed then SMSC GW will not include UDH value into message). UDH should be created by client
 |===
 
 Format parameter controls the response format to the request. Response contains the status of request, it can be “Success” or “Error”. In case of error it contains an error code and error message. In case of success response contains a list of pairs: “request ID / destination
@@ -1383,7 +1384,7 @@ http://127.0.0.1:8080/{this-httpprefix}/sendSms?userid=user1&password=password&m
 
 http://127.0.0.1:8080/{this-httpprefix}/sendSms?userid=user1&password=password&msg=exampleMessage_02&format=String&smscEncoding=GSM7&messageBodyEncoding=UTF8&sender=1234&to=1111
 
-http://127.0.0.1:8080/{this-httpprefix}/sendSms?userid=user1&password=password&msg=exampleMessage_03&format=json&smscEncoding=UCS2&messageBodyEncoding=UTF16&sender=4321&to=6666,6667&senderTon=5&senderNpi=0
+http://127.0.0.1:8080/{this-httpprefix}/sendSms?userid=user1&password=password&msg=exampleMessage_03&format=json&smscEncoding=UCS2&messageBodyEncoding=UTF16&sender=4321&to=6666,6667&senderTon=5&senderNpi=0&udh=%06%05%04%13%01%13%01
 ----
 
 Response examples:


### PR DESCRIPTION
Hi, I have done the code for udh param in http

I have tested:
- verify udh param
- send sms from http without udh to simulator and check the udh is not encode there
-send sms from http with udh and check udh is encoded in wireshark, check message is received at simulator

example
http://127.0.0.1:8080/restcomm/sendSms?userid=user1&password=password&msg=test&format=json&messageBodyEncoding=UTF8&sender=ABCDEF&senderTon=5&senderNpi=0&to=966505980169&udh=06%05%04%13%01%13%01

Br,
TN