### PR TITLE
fix #176

### DIFF
--- a/core/bootstrap/src/main/config/data/SmscManagement_smscproperties.xml
+++ b/core/bootstrap/src/main/config/data/SmscManagement_smscproperties.xml
@@ -44,6 +44,8 @@
 <globalTitleIndicator value="GLOBAL_TITLE_INCLUDES_TRANSLATION_TYPE_NUMBERING_PLAN_ENCODING_SCHEME_AND_NATURE_OF_ADDRESS"/>
 <translationType value="0"/>
 <correlationIdLiveTime value="60"/>
+<cassandraUser value="cassandra"/>
+<cassandraPass value="cassandra"/>
 <diameterDestRealm value="telestax.com"/>
 <diameterDestHost value="127.0.0.1"/>
 <diameterDestPort value="3868"/>

--- a/core/domain/src/main/java/org/mobicents/smsc/domain/SMSCShellExecutor.java
+++ b/core/domain/src/main/java/org/mobicents/smsc/domain/SMSCShellExecutor.java
@@ -45,6 +45,7 @@ import org.restcomm.smpp.SmppEncoding;
 /**
  * @author amit bhayani
  * @author sergey vetyutnev
+ * @author tran nhan
  * 
  */
 public class SMSCShellExecutor implements ShellExecutor {
@@ -1005,7 +1006,13 @@ public class SMSCShellExecutor implements ShellExecutor {
             } else if (parName.equals("deliverypause")) {
                 boolean val = Boolean.parseBoolean(options[3]);
                 smscPropertiesManagement.setDeliveryPause(val);
-			} else {
+			} else if (parName.equals("cassandrauser")) {
+                String val = String.valueOf(options[3]);
+                smscPropertiesManagement.setCassandraUser(val);
+            } else if (parName.equals("cassandrapass")) {
+                String val = String.valueOf(options[3]);
+                smscPropertiesManagement.setCassandraPass(val);
+            } else {
 				return SMSCOAMMessages.INVALID_COMMAND;
 			}
 		} catch (IllegalArgumentException e) {
@@ -1268,7 +1275,12 @@ public class SMSCShellExecutor implements ShellExecutor {
 
             } else if (parName.equals("deliverypause")) {
                 sb.append(smscPropertiesManagement.isDeliveryPause());
-			} else {
+			} else if (parName.equals("cassandrauser")) {
+                sb.append(smscPropertiesManagement.getCassandraPass());
+            } else if (parName.equals("cassandrapass")) {
+                sb.append(smscPropertiesManagement.getCassandraPass());
+            }
+            else {
 				return SMSCOAMMessages.INVALID_COMMAND;
 			}
 
@@ -1627,7 +1639,15 @@ public class SMSCShellExecutor implements ShellExecutor {
             sb.append(smscPropertiesManagement.isDeliveryPause());
             sb.append("\n");
 
-			return sb.toString();
+            sb.append("cassandrauser = ");
+            sb.append(smscPropertiesManagement.getCassandraUser());
+            sb.append("\n");
+
+            sb.append("cassandrapass = ");
+            sb.append(smscPropertiesManagement.getCassandraPass());
+            sb.append("\n");
+
+            return sb.toString();
 		}
 	}
 

--- a/core/domain/src/main/java/org/mobicents/smsc/domain/SmscManagement.java
+++ b/core/domain/src/main/java/org/mobicents/smsc/domain/SmscManagement.java
@@ -253,6 +253,7 @@ public class SmscManagement implements SmscManagementMBean {
         String hosts = smscPropertiesManagement.getDbHosts();
         int port = smscPropertiesManagement.getDbPort();
         DBOperations.getInstance().start(hosts, port, this.smscPropertiesManagement.getKeyspaceName(),
+                this.smscPropertiesManagement.getCassandraUser(), this.smscPropertiesManagement.getCassandraPass(),
                 this.smscPropertiesManagement.getFirstDueDelay(), this.smscPropertiesManagement.getReviseSecondsOnSmscStart(),
                 this.smscPropertiesManagement.getProcessingSmsSetTimeout(), this.smscPropertiesManagement.getMinMessageId(),
                 this.smscPropertiesManagement.getMaxMessageId());

--- a/core/domain/src/main/java/org/mobicents/smsc/domain/SmscPropertiesManagement.java
+++ b/core/domain/src/main/java/org/mobicents/smsc/domain/SmscPropertiesManagement.java
@@ -137,6 +137,8 @@ public class SmscPropertiesManagement implements SmscPropertiesManagementMBean {
 
     private static final String DELIVERY_PAUSE = "deliveryPause";
 
+    private static final String CASSANDRA_USER = "cassandraUser";
+    private static final String CASSANDRA_PASS = "cassandraPass";
 
 	private static final String TAB_INDENT = "\t";
 	private static final String CLASS_ATTRIBUTE = "type";
@@ -198,6 +200,10 @@ public class SmscPropertiesManagement implements SmscPropertiesManagementMBean {
 	private int dbPort = 9042;
 	private String keyspaceName = "RestCommSMSC";
 	private String clusterName = "RestCommSMSC";
+
+    // credential for cassandra
+    private String cassandraUser = "cassandra";
+    private String cassandraPass = "cassandra";
 
 	// period of fetching messages from a database for delivering
 	// private long fetchPeriod = 5000; // that was C1
@@ -579,6 +585,34 @@ public class SmscPropertiesManagement implements SmscPropertiesManagementMBean {
 		this.dueDelayMultiplicator = dueDelayMultiplicator;
 		this.store();
 	}
+
+    public void setCassandraUser(String user) throws IllegalArgumentException {
+
+        if (user.trim().equals("")) {
+            throw new IllegalArgumentException("User name can not be empty");
+        }
+
+        this.cassandraUser = user.trim();
+        this.store();
+    }
+
+    public String getCassandraUser() {
+        return this.cassandraUser;
+    }
+
+    public void setCassandraPass(String pass) throws IllegalArgumentException {
+
+        if (pass.trim().equals("")) {
+            throw new IllegalArgumentException("Password can not be empty");
+        }
+
+        this.cassandraPass = pass.trim();
+        this.store();
+    }
+
+    public String getCassandraPass() {
+        return this.cassandraPass;
+    }
 
 	@Override
 	public int getMaxMessageLengthReducer() {
@@ -1507,6 +1541,9 @@ public class SmscPropertiesManagement implements SmscPropertiesManagementMBean {
             writer.write(this.httpDefaultRDIntermediateNotification, HTTP_DEFAULT_RD_INTERMEDIATE_NOTIFICATION, Integer.class);
             writer.write(this.httpDefaultDataCoding, HTTP_DEFAULT_DATA_CODING, Integer.class);
 
+            writer.write(this.cassandraUser, CASSANDRA_USER, String.class);
+            writer.write(this.cassandraPass, CASSANDRA_PASS, String.class);
+
             writer.write(this.diameterDestRealm, DIAMETER_DEST_REALM, String.class);
 			writer.write(this.diameterDestHost, DIAMETER_DEST_HOST, String.class);
 			writer.write(this.diameterDestPort, DIAMETER_DEST_PORT, Integer.class);
@@ -1822,6 +1859,14 @@ public class SmscPropertiesManagement implements SmscPropertiesManagementMBean {
             val = reader.read(HTTP_DEFAULT_DATA_CODING, Integer.class);
             if (val != null)
                 this.httpDefaultDataCoding = val;
+
+            vals = reader.read(CASSANDRA_USER, String.class);
+            if (vals != null)
+                this.cassandraUser = vals;
+
+            vals = reader.read(CASSANDRA_PASS, String.class);
+            if (vals != null)
+                this.cassandraPass = vals;
 
             this.diameterDestRealm = reader.read(DIAMETER_DEST_REALM, String.class);
 

--- a/core/domain/src/main/java/org/mobicents/smsc/domain/SmscPropertiesManagementMBean.java
+++ b/core/domain/src/main/java/org/mobicents/smsc/domain/SmscPropertiesManagementMBean.java
@@ -373,4 +373,12 @@ public interface SmscPropertiesManagementMBean {
 
     public void setMaxMessageId(long maxMessageId) throws IllegalArgumentException;
 
+    public void setCassandraUser(String user) throws  IllegalArgumentException;
+
+    public String getCassandraUser();
+
+    public void setCassandraPass(String pass) throws  IllegalArgumentException;
+
+    public String getCassandraPass();
+
 }

--- a/core/domain/src/test/java/org/mobicents/smsc/domain/DbSmsRoutingRuleTest.java
+++ b/core/domain/src/test/java/org/mobicents/smsc/domain/DbSmsRoutingRuleTest.java
@@ -51,7 +51,7 @@ public class DbSmsRoutingRuleTest {
         this.cassandraDbInited = this.sbb.testCassandraAccess();
         if (!this.cassandraDbInited)
             return;
-        this.sbb.start("127.0.0.1", 9042, "RestCommSMSC", 60, 60, 60 * 10, 1, 10000000000L);
+        this.sbb.start("127.0.0.1", 9042, "RestCommSMSC", "cassandra", "cassandra", 60, 60, 60 * 10, 1, 10000000000L);
 //        String ip, int port, String keyspace, int secondsForwardStoring, int reviseSecondsOnSmscStart,
 //        int processingSmsSetTimeout
     }

--- a/core/domain/src/test/java/org/mobicents/smsc/domain/SmscDatabaseManagementTest.java
+++ b/core/domain/src/test/java/org/mobicents/smsc/domain/SmscDatabaseManagementTest.java
@@ -29,7 +29,7 @@ public class SmscDatabaseManagementTest {
         if (cassandraDbInited) {
             try {
                 this.db = DBOperations.getInstance();
-                this.db.start(ip, 9042, keyspace, 60, 60, 60 * 10, 1, 10000000000L);
+                this.db.start(ip, 9042, keyspace, "cassandra", "cassandra", 60, 60, 60 * 10, 1, 10000000000L);
             } catch (Exception e) {
             }
         }

--- a/core/domain/src/test/java/org/mobicents/smsc/domain/TT_PersistenceProxy.java
+++ b/core/domain/src/test/java/org/mobicents/smsc/domain/TT_PersistenceProxy.java
@@ -44,7 +44,7 @@ public class TT_PersistenceProxy extends DBOperations {
     private static final Logger logger = Logger.getLogger(TT_PersistenceProxy.class);
 
     public void start() throws Exception {
-        super.start("127.0.0.1", 9042, "RestCommSMSC", 60, 60, 60 * 10, 1, 10000000000L);
+        super.start("127.0.0.1", 9042, "RestCommSMSC", "cassandra", "cassandra", 60, 60, 60 * 10, 1, 10000000000L);
     }
 
     public boolean testCassandraAccess() {

--- a/core/oam/cli/src/main/java/org/mobicents/ss7/management/console/impl/SmscCommandHandler.java
+++ b/core/oam/cli/src/main/java/org/mobicents/ss7/management/console/impl/SmscCommandHandler.java
@@ -142,6 +142,8 @@ public class SmscCommandHandler extends CommandHandlerWithHelp {
         set.addChild("receiptsdisabling");
         set.addChild("incomereceiptsprocessing");
         set.addChild("orignetworkidforreceipts");
+        set.addChild("cassandrauser");
+        set.addChild("cassandrapass");
 
 		Node get = parent.addChild("get");
 		get.addChild("scgt");
@@ -213,6 +215,8 @@ public class SmscCommandHandler extends CommandHandlerWithHelp {
         get.addChild("receiptsdisabling");
         get.addChild("incomereceiptsprocessing");
         get.addChild("orignetworkidforreceipts");
+        get.addChild("cassandrauser");
+        get.addChild("cassandrapass");
 
         Node remove = parent.addChild("remove");
         remove.addChild("esmedefaultcluster");

--- a/core/oam/cli/src/main/resources/help/smsc_get_cassandrapass.txt
+++ b/core/oam/cli/src/main/resources/help/smsc_get_cassandrapass.txt
@@ -1,0 +1,17 @@
+Name
+	smsc get cassandrapass
+
+SYNOPSIS
+	smsc get cassandrapass
+
+DESCRIPTION
+	This command is used to get the password for Cassandra Database
+	access.
+
+EXAMPLES
+	smsc get cassandrapass
+
+SEE ALSO
+	smsc esme_create, smsc get scgt, smsc get scssn, smsc get scssn, smsc get hlrssn,
+	smsc get hlrssn, smsc get mscssn, smsc set mscssn, smsc get maxmapv,
+	smsc get maxmapv

--- a/core/oam/cli/src/main/resources/help/smsc_get_cassandrauser.txt
+++ b/core/oam/cli/src/main/resources/help/smsc_get_cassandrauser.txt
@@ -1,0 +1,16 @@
+Name
+	smsc get cassandrauser
+
+SYNOPSIS
+	smsc get cassandrauser
+
+DESCRIPTION
+	This command is used to get the user account for Cassandra Database
+	access.
+
+EXAMPLES
+	smsc get calculatemsgpartslencdr
+
+SEE ALSO
+	smsc get generatereceiptcdr, smsc get generatetempfailurecdr,
+	smsc get calculatemsgpartslencdr, smsc get generatecdr

--- a/core/oam/cli/src/main/resources/help/smsc_set_cassandrapass.txt
+++ b/core/oam/cli/src/main/resources/help/smsc_set_cassandrapass.txt
@@ -1,0 +1,18 @@
+Name
+	smsc set cassandrapass <user-name>
+
+SYNOPSIS
+	smsc set cassandrapass
+
+DESCRIPTION
+	This command is used to set the user account for Cassandra Database
+	access.
+	The command need SMSC GW to be restarted to take effect.
+
+EXAMPLES
+	smsc set cassandrapass cassandra
+
+SEE ALSO
+	smsc esme_create, smsc get scgt, smsc get scssn, smsc set scssn, smsc get hlrssn,
+	smsc set hlrssn, smsc get mscssn, smsc set mscssn, smsc get maxmapv, 
+	smsc set maxmapv

--- a/core/oam/cli/src/main/resources/help/smsc_set_cassandrauser.txt
+++ b/core/oam/cli/src/main/resources/help/smsc_set_cassandrauser.txt
@@ -1,0 +1,18 @@
+Name
+	smsc set cassandrauser <user-name>
+
+SYNOPSIS
+	smsc set cassandrauser
+
+DESCRIPTION
+	This command is used to set the user account for Cassandra Database
+	access.
+	The command need SMSC GW to be restarted to take effect.
+
+EXAMPLES
+	smsc set cassandrauser cassandra
+
+SEE ALSO
+	smsc esme_create, smsc get scgt, smsc get scssn, smsc set scssn, smsc get hlrssn,
+	smsc set hlrssn, smsc get mscssn, smsc set mscssn, smsc get maxmapv, 
+	smsc set maxmapv

--- a/core/slee/resource-adaptors/persistence-ra/ra/src/test/java/org/mobicents/smsc/slee/resources/persistence/PersistenceRAInterfaceProxy.java
+++ b/core/slee/resource-adaptors/persistence-ra/ra/src/test/java/org/mobicents/smsc/slee/resources/persistence/PersistenceRAInterfaceProxy.java
@@ -70,11 +70,11 @@ public class PersistenceRAInterfaceProxy extends DBOperations implements Persist
     }
 
     public void start() throws Exception {
-        super.start(ip, 9042, keyspace, 60, 60, 60 * 10, 1, 10000000000L);
+        super.start(ip, 9042, keyspace, "cassandra", "cassandra", 60, 60, 60 * 10, 1, 10000000000L);
     }
 
     public void startMinMaxMessageId(long minMessageId, long maxMessageId) throws Exception {
-        super.start(ip, 9042, keyspace, 60, 60, 60 * 10, minMessageId, maxMessageId);
+        super.start(ip, 9042, keyspace, "cassandra", "cassandra", 60, 60, 60 * 10, minMessageId, maxMessageId);
     }
 
     public void setOldShortMessageDbFormat(boolean val) {

--- a/core/smsc-common-library/src/main/java/org/mobicents/smsc/cassandra/DBOperations.java
+++ b/core/smsc-common-library/src/main/java/org/mobicents/smsc/cassandra/DBOperations.java
@@ -214,8 +214,8 @@ public class DBOperations {
         return this.session;
     }
 
-    public void start(String hosts, int port, String keyspace, int secondsForwardStoring, int reviseSecondsOnSmscStart,
-            int processingSmsSetTimeout, long minMessageId, long maxMessageId) throws Exception {
+    public void start(String hosts, int port, String keyspace, String user, String password, int secondsForwardStoring,
+                      int reviseSecondsOnSmscStart, int processingSmsSetTimeout, long minMessageId, long maxMessageId) throws Exception {
 		if (this.started) {
 			throw new IllegalStateException("DBOperations already started");
 		}
@@ -237,6 +237,7 @@ public class DBOperations {
             String[] cassHostsArray = hosts.split(",");
             builder.addContactPoints(cassHostsArray);
             builder.withPort(port);
+            builder.withCredentials(user, password);
 
             this.cluster = builder.build().init();
         } catch (Exception e) {

--- a/core/smsc-common-library/src/test/java/org/mobicents/smsc/cassandra/CassTest.java
+++ b/core/smsc-common-library/src/test/java/org/mobicents/smsc/cassandra/CassTest.java
@@ -14,7 +14,7 @@ public class CassTest {
 //            int g1 = 0;
 //            g1++;
 //        }                
-        db.start("127.0.0.1", 9042, keySpacename, 60, 60, 60 * 10, 1, 10000000000L);
+        db.start("127.0.0.1", 9042, keySpacename, "cassandra", "cassandra", 60, 60, 60 * 10, 1, 10000000000L);
 
 
         db.c2_setCurrentDueSlot(2009);
@@ -22,7 +22,7 @@ public class CassTest {
 
 //        Thread.sleep(1000);
 
-        db.start("127.0.0.1", 9042, keySpacename, 60, 60, 60 * 10, 1, 10000000000L);
+        db.start("127.0.0.1", 9042, keySpacename, "cassandra", "cassandra", 60, 60, 60 * 10, 1, 10000000000L);
 
         long l1 = db.c2_getCurrentSlotTable(0);
         long l2 = db.c2_getCurrentSlotTable(0);

--- a/core/smsc-common-library/src/test/java/org/mobicents/smsc/library/test/DBOperTesting.java
+++ b/core/smsc-common-library/src/test/java/org/mobicents/smsc/library/test/DBOperTesting.java
@@ -34,7 +34,7 @@ public class DBOperTesting {
             logger.info("starting DBOperations_C2 ...");
             String keySpacename = "RestCommSMSC1";
 //            String keySpacename = "RestCommSMSC";
-            db.start("127.0.0.1", 9042, keySpacename, 60, 60, 60 * 10, 1, 10000000000L);
+            db.start("127.0.0.1", 9042, keySpacename, "cassandra", "cassandra", 60, 60, 60 * 10, 1, 10000000000L);
 
             logger.info("DBOperations_C2 is started");
             

--- a/docs/adminguide/sources-asciidoc/src/main/asciidoc/Section-Managing-Server-Settings.adoc
+++ b/docs/adminguide/sources-asciidoc/src/main/asciidoc/Section-Managing-Server-Settings.adoc
@@ -1229,6 +1229,80 @@ EXAMPLES
 . You must click on the button 'Apply Changes' at the top of the window to save your settings.
   If there is an error in setting the value, then you will find the details of the error in the Management Console Log section below. 
 
+----
+
+[[cassandra_user]]
+=== Cassandra Configuration - User Name
+
+[[_cassandra_user_cli]]
+==== Using CLI
+
+You can set the 'Cassandra User Name' by issuing the command `smsc set cassandrauser` with appropriate parameters as described below.
+You can verify this by issuing the command `smsc get cassandrauser` which will display the value set for this property.
+
+----
+
+Name
+	smsc set cassandrauser
+
+SYNOPSIS
+	smsc set cassandrauser <username>
+
+DESCRIPTION
+	This command is used to set the user name for Cassandra Database. Default user is `cassandra`
+	You must restart SMSC GW to take effect.
+
+----
+
+[[_cassandra_user_gui]]
+==== Using GUI
+
+.Procedure: Set Cassandra Configuration - User Name using the GUI
+. In the GUI Management Console for SMSC Gateway, click on 'Server Settings' in the left panel.
+. The main panel will display the existing Settings, segregated into eight horizontal tabs: Properties, SS7 Settings, Cassandra, Scheduler, Diameter, Processing, CDR and Home Routing.
+  Switch to the 'Cassandra' tab in the GUI.
+. You can specify the User Name by entering the value in the text field 'User Name'. For more details of this parameter, please refer to the description of the CLI command for the same in the preceding section.
+. You must click on the button 'Apply Changes' at the top of the window to save your settings.
+  If there is an error in setting the value, then you will find the details of the error in the Management Console Log section below.
+
+----
+
+[[cassandra_pass]]
+=== Cassandra Configuration - Password
+
+[[_cassandra_pass_cli]]
+==== Using CLI
+
+You can set the 'Cassandra Password' by issuing the command `smsc set cassandrapass` with appropriate parameters as described below.
+You can verify this by issuing the command `smsc get cassandrapass` which will display the value set for this property.
+
+----
+
+Name
+	smsc set cassandrapass
+
+SYNOPSIS
+	smsc set cassandrapass <password>
+
+DESCRIPTION
+	This command is used to set the password for Cassandra Database. Default password is `cassandra`
+	You must restart SMSC GW to take effect.
+
+----
+
+[[_cassandra_user_gui]]
+==== Using GUI
+
+.Procedure: Set Cassandra Configuration - Password using the GUI
+. In the GUI Management Console for SMSC Gateway, click on 'Server Settings' in the left panel.
+. The main panel will display the existing Settings, segregated into eight horizontal tabs: Properties, SS7 Settings, Cassandra, Scheduler, Diameter, Processing, CDR and Home Routing.
+  Switch to the 'Cassandra' tab in the GUI.
+. You can specify the Cassandra Password by entering the value in the text field 'Password'. For more details of this parameter, please refer to the description of the CLI command for the same in the preceding section.
+. You must click on the button 'Apply Changes' at the top of the window to save your settings.
+  If there is an error in setting the value, then you will find the details of the error in the Management Console Log section below.
+
+----
+
 [[_db_removinglivetablesdays]]
 === Cassandra Configuration - Removing Live Tables Days
 

--- a/management/ui-management/src/main/webapp/modules/server-settings.html
+++ b/management/ui-management/src/main/webapp/modules/server-settings.html
@@ -303,6 +303,20 @@ Empty TC-BEGIN is used in MAP Version 2 and 3 for forwardSM and Mt- ForwardSM re
 									<input id="cassandraclustername" type="text" class="input-mini" style="width: 100px; margin-right: 12px; text-align: center;" value="0" />
 								</span>                         
 							</div>
+                             <div id="div-cassandrauser" class="control-group">
+								<span class="input-prepend" data-toggle="tooltip" data-placement="bottom" title="cassandra user name">
+									<span class="add-on">User</span>
+									<input id="cassandrauser" type="text" class="input-mini" style="width: 100px; margin-right: 12px; text-align: center;" value="0" />
+								</span>
+							</div>
+
+							<div id="div-cassandrapass" class="control-group">
+								<span class="input-prepend" data-toggle="tooltip" data-placement="bottom" title="cassandra password">
+									<span class="add-on">Password</span>
+									<input id="cassandrapass" type="text" class="input-mini" style="width: 100px; margin-right: 12px; text-align: center;" value="0" />
+								</span>
+							</div>
+
 							<h5 style="border-bottom: 1px solid #DDD;">Archive Table Configuration</h5>
 							<div id="div-removinglivetablesdays" class="control-group">
 								<span class="input-prepend" data-toggle="tooltip" data-placement="bottom" title="configure the SMSC to automatically drop LIVE tables from the Cassandra Database. The SMSC will attempt to delete tables just after midnight and after every SMSC restart. This parameter is used to specify the number of days the LIVE tables should be kept before attempting to drop them automatically. If this value is specified as 0, the SMSC will not drop tables automatically. In this case you must manually drop tables. You must specify a value of 3 or more. You can not set this value to 1 or 2 days. This is to ensure the tables will be kept for a minimum of 2 days after creation date. The SMSC wil attempt to delete tables for one day. If the Cassandra Database keeps tables for older days, then the administrator should drop these manually.">
@@ -915,6 +929,8 @@ day. If the Cassandra Database keeps tables for older days, then the administrat
 										$("#cassandraport").val(cassandraport);
 										$("#cassandrakeyspace").val(response.value.KeyspaceName);
 										$("#cassandraclustername").val(response.value.ClusterName);
+										$("#cassandrauser").val(response.value.CassandraUser);
+										$("#cassandrapass").val(response.value.CassandraPass);
 										
 										$("#removinglivetablesdays").val(response.value.RemovingLiveTablesDays);
 										$("#removingarchivetabledays").val(response.value.RemovingArchiveTablesDays);										
@@ -1714,7 +1730,22 @@ day. If the Cassandra Database keeps tables for older days, then the administrat
 			    		}
 						
 						var cassandraclustername = $("#cassandraclustername").val();
-						
+
+						var cassandrauser = $("#cassandrauser").val();
+						if(cassandrauser.trim() == "") {
+			    			$("#div-cassandrauser").addClass("error");
+			    			formInvalid = true;
+			    		} else if($("#div-cassandrauser").hasClass("error")) {
+			    			$("#div-cassandrauser").removeClass("error");
+			    		}
+
+						var cassandrapass =  $("#cassandrapass").val();
+						if(cassandrapass.trim() == "") {
+			    			$("#div-cassandrapass").addClass("error");
+			    			formInvalid = true;
+			    		} else if($("#div-cassandrapass").hasClass("error")) {
+			    			$("#div-cassandrapass").removeClass("error");
+			    		}
 						
 						var removinglivetablesdays = $("#removinglivetablesdays").val();
 						if(removinglivetablesdays.trim() == "") {
@@ -1749,6 +1780,8 @@ day. If the Cassandra Database keeps tables for older days, then the administrat
 									{ type: "write", mbean: mbeanSearch, attribute: "DbPort", value: cassandraport },
 									{ type: "write", mbean: mbeanSearch, attribute: "KeyspaceName", value: cassandrakeyspace },
 									{ type: "write", mbean: mbeanSearch, attribute: "ClusterName", value: cassandraclustername },
+									{ type: "write", mbean: mbeanSearch, attribute: "CassandraUser", value: cassandrauser },
+									{ type: "write", mbean: mbeanSearch, attribute: "CassandraPass", value: cassandrapass },
 									{ type: "write", mbean: mbeanSearch, attribute: "RemovingLiveTablesDays", value: removinglivetablesdays },
 									{ type: "write", mbean: mbeanSearch, attribute: "RemovingArchiveTablesDays", value: removingarchivetabledays },
 								],

--- a/tools/cassandra-tool/cassandratool/src/main/java/org/mobicents/smsc/tools/cassandratool/CassandraToolForm.java
+++ b/tools/cassandra-tool/cassandratool/src/main/java/org/mobicents/smsc/tools/cassandratool/CassandraToolForm.java
@@ -80,6 +80,8 @@ public class CassandraToolForm {
 
     private JTextField tbHost;
     private JTextField tbPort;
+    private JTextField tbUser;
+    private JTextField tbPass;
     private JTextField tbKeyspace;
     private JTable tResult;
     protected JFrame frmSmppSimulator;
@@ -198,6 +200,7 @@ public class CassandraToolForm {
         
         tbPort = new JTextField();
         tbPort.setBounds(145, 40, 125, 20);
+
         panel_2.add(tbPort);
         tbPort.setText("9042");
         tbPort.setColumns(10);
@@ -207,6 +210,18 @@ public class CassandraToolForm {
         panel_2.add(tbHost);
         tbHost.setText("127.0.0.1");
         tbHost.setColumns(10);
+
+        tbUser = new JTextField();
+        tbPort.setBounds(145, 40, 125, 20);
+        panel_2.add(tbUser);
+        tbUser.setText("cassandra");
+        tbUser.setColumns(10);
+
+        tbPass = new JTextField();
+        tbPort.setBounds(145, 40, 125, 20);
+        panel_2.add(tbPass);
+        tbPass.setText("cassandra");
+        tbPass.setColumns(10);
 
         btConnect = new JButton("Connect");
         btConnect.addActionListener(new ActionListener() {
@@ -263,6 +278,8 @@ public class CassandraToolForm {
         this.dbOperations = new DBOperationsProxy();
         String hosts = this.tbHost.getText();
         String strPort = this.tbPort.getText();
+        String user = this.tbUser.getText();
+        String pass = this.tbPass.getText();
         int port = 0;
         try {
             port = Integer.parseInt(strPort);
@@ -272,7 +289,7 @@ public class CassandraToolForm {
         }
         String keyspace = this.tbKeyspace.getText();
         try {
-            this.dbOperations.start(hosts, port, keyspace, 60, 60, 60 * 10, 1, 10000000000L);
+            this.dbOperations.start(hosts, port, keyspace, user, pass, 60, 60, 60 * 10, 1, 10000000000L);
         } catch (Exception e) {
             JOptionPane.showMessageDialog(getJFrame(), "Can not connect to cassandra database:\n" + e.getMessage());
             return;

--- a/tools/stresstool/stresstool/src/main/java/org/mobicents/smsc/tools/stresstool/StressTool3.java
+++ b/tools/stresstool/stresstool/src/main/java/org/mobicents/smsc/tools/stresstool/StressTool3.java
@@ -38,6 +38,8 @@ public class StressTool3 {
     private String host = "localhost";
     private int port = 9042;
     private String keyspace = "saturn";
+    private String user = "cassandra";
+    private String pass = "cassandra";
     private int dataTableDaysTimeArea = 10;
     private int smsSetRange = 10;
     private int recordCount = 500000;
@@ -83,7 +85,7 @@ public class StressTool3 {
         // -dDataTableDaysTimeArea
 
         this.dbOperations = new TT_DBOperationsProxy3();
-        this.dbOperations.start(host, port, keyspace, 60, 60, 60 * 10, 1, 10000000000L);
+        this.dbOperations.start(host, port, keyspace, user, pass, 60, 60, 60 * 10, 1, 10000000000L);
 
         
         


### PR DESCRIPTION
            - new cli/webmanagement commands are added:
	        + smsc set cassandrauser <username>
		+ smsc set cassandrapass <password>
		+ smsc get cassandrauser
		+ smsc get cassandrapass
[smsc_cassandra_authen.patch.txt](https://github.com/RestComm/smscgateway/files/946194/smsc_cassandra_authen.patch.txt)
