### PR TITLE
fix for NPE in CdrGenerator

### DIFF
--- a/core/smsc-common-library/src/main/java/org/mobicents/smsc/library/CdrGenerator.java
+++ b/core/smsc-common-library/src/main/java/org/mobicents/smsc/library/CdrGenerator.java
@@ -312,13 +312,16 @@ public class CdrGenerator {
     }
 
     private static String getEscapedString(final String aValue) {
+	    if (aValue == null) {
+	        return CDR_EMPTY;
+        }
 	    return aValue.replaceAll("\n", "n").replaceAll(",", " ").replace("\"", "'").replace('\u0000', '?').replace('\u0006', '?');
     }
 
     private static String getProcessingTime(final Date aSubmitDate) {
         if (aSubmitDate == null) {
             return CDR_EMPTY;
-}
+        }
         return String.valueOf(System.currentTimeMillis() - aSubmitDate.getTime());
     }
 


### PR DESCRIPTION
Fix for NullPointerException in CdrGenerator. Problem occurs when 'generate rejection cdr' option is enabled. Checking if cdr parameter is null already added.