### PR TITLE
Message ID filtering (SMSCGW to deal with messages that have certain message IDs)

### DIFF
--- a/core/slee/resource-adaptors/scheduler-ra/ra/src/main/java/org/mobicents/smsc/slee/resources/scheduler/SchedulerResourceAdaptor.java
+++ b/core/slee/resource-adaptors/scheduler-ra/ra/src/main/java/org/mobicents/smsc/slee/resources/scheduler/SchedulerResourceAdaptor.java
@@ -947,7 +947,7 @@ public class SchedulerResourceAdaptor implements ResourceAdaptor {
             return new OneWaySmsSetCollection();
         }
 
-        ArrayList<SmsSet> lstS = dbOperations_C2.c2_getRecordList(processedDueSlot);
+        ArrayList<SmsSet> lstS = filterOut(dbOperations_C2.c2_getRecordList(processedDueSlot));
         ArrayList<SmsSet> lst = dbOperations_C2.c2_sortRecordList(lstS);
         OneWaySmsSetCollection res = new OneWaySmsSetCollection();
         res.setListSmsSet(lst);
@@ -1027,4 +1027,17 @@ public class SchedulerResourceAdaptor implements ResourceAdaptor {
 			return lst.size() - uploadedCount;
 		}
 	}
+
+	private static ArrayList<SmsSet> filterOut(final List<SmsSet> anInputList) {
+        final ArrayList<SmsSet> result = new ArrayList<SmsSet>(0);
+        final long min = SmscPropertiesManagement.getInstance().getMinMessageId();
+        final long max = SmscPropertiesManagement.getInstance().getMaxMessageId();
+        for (final SmsSet set : anInputList) {
+            if (set.isMessageIdOk(min, max)) {
+                result.add(set);
+            }
+        }
+        return result;
+    }
+
 }

--- a/core/smsc-common-library/src/main/java/org/mobicents/smsc/library/SmsSet.java
+++ b/core/smsc-common-library/src/main/java/org/mobicents/smsc/library/SmsSet.java
@@ -524,7 +524,23 @@ public class SmsSet implements Serializable {
         return this.sendingMessagePool.size();
     }
 
-	@Override
+    public boolean isMessageIdOk(final long aMinValue, final long aMaxValue) {
+        for (final Segment segment : segmList) {
+            for (final Sms sms : segment.smsList) {
+                final long mid = sms.getMessageId();
+                if (mid < aMinValue) {
+                    continue;
+                }
+                if (mid > aMinValue) {
+                    continue;
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 


### PR DESCRIPTION
Hi,

can you please review and consider this PR?

It is needed when trying to run 2 SMSCGW instances connected to cluster of 2 Cassandra nodes.

When SMSC checks for messages that should be re-sent, the instances should deal only with its 'own' messages (each SMSCGW has its own not-overlapping MsgID range).

Possibly it could be resolved in a better way. Anybody has any other ideas on how to achieve it?

Possibly this feature can be made configurable (to be turned on/off by configuration).

With kind regards,
adam