### PR TITLE
Added guides for Issue & PR Creation

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!-- This form is for bug reports and feature requests ONLY! 
+
+If you're looking for help check [Stack Overflow](https://stackoverflow.com/questions/tagged/restcomm).
+-->
+
+**Is this a BUG REPORT or FEATURE REQUEST?**:
+
+> Uncomment only one, leave it on its own line, delete the rest of these comments: 
+>
+> /kind bug
+>
+> /kind feature
+
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Restcomm SMSC Gateway version (from startup logs):
+- Cloud provider or hardware configuration:
+- OS (e.g. from /etc/os-release):
+- Kernel (e.g. `uname -a`):
+- Deployment method (e.g. application server version + config + method):
+- Others:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+1. If this is your first time, read the Telestax Open Source Playbook https://docs.google.com/document/d/1RZz2nd2ivCK_rg1vKX9ansgNF6NpK_PZl81GxZ2MSnM/edit?usp=sharing
+2. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes** 
+
+> (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will
+> close the issue(s) when PR gets merged). Please delete these comments and mark `N/A`
+> if non-applicable.
+>
+> Fixes #
+
+**Special notes for your reviewer**:

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,41 @@
+## Support for deploying and using Restcomm 
+
+Welcome to Restcomm! We use GitHub for tracking bugs and feature requests. 
+This isn't the right place to get support for using Restcomm, but there are other free resources you can use
+for that, if you don't want to purchase one of the [Telestax commercial support packages](https://telestax.com/support/). 
+
+Please help us better maintain these FOSS projects by following these guidelines and not raising help-related issues here. 
+
+Thanks in advance for your understanding!
+
+### Stack Overflow
+
+The Restcomm Community is active on Stack Overflow, you can post your questions there: 
+
+* [Restcomm on Stack Overflow](http://stackoverflow.com/questions/tagged/restcomm)
+
+  * Here are some tips for [about how to ask good questions](http://stackoverflow.com/help/how-to-ask).
+  * Don't forget to check to see [what's on topic](http://stackoverflow.com/help/on-topic).
+
+### Mailing Lists / Groups
+
+You can find answers for older questions also in our 
+[[Mobicents-Public]](https://groups.google.com/forum/#!forum/mobicents-public) 
+and [[Restcomm]](https://groups.google.com/forum/#!forum/restcomm) mailing lists. 
+
+**Please avoid raising new issues** in the mailing lists, as we will be migrating away from these soon. 
+
+### Documentation 
+
+* Documentation is available on the [Restcomm Site](https://www.restcomm.com/docs/) 
+
+
+### Real-time Chat
+
+* You can use the public [Restcomm Discuss Gitter channel](https://gitter.im/RestComm/Restcomm-discuss) for general issues.
+
+
+
+<!---
+Inspired from https://github.com/kubernetes/kubernetes/blob/master/SUPPORT.md
+--> 


### PR DESCRIPTION
Includes instructions on where to find support, when to open new issues / pull requests, links to Telestax Open Source Playbook, etc.

This should help community users create better issues / PRs that make it easier for maintainers to engage.