### PR TITLE
[#289] Flag to tag timeouts as permanent failure

### DIFF
--- a/core/domain/src/main/java/org/mobicents/smsc/domain/SmscPropertiesManagement.java
+++ b/core/domain/src/main/java/org/mobicents/smsc/domain/SmscPropertiesManagement.java
@@ -140,6 +140,8 @@ public class SmscPropertiesManagement implements SmscPropertiesManagementMBean {
     private static final String MIN_MESSAGE_ID = "minMessageId";
     private static final String MAX_MESSAGE_ID = "maxMessageId";
 
+    private static final String MARK_TIMEOUT_AS_PERMANENT_FAILURE = "markTimeoutAsPermanentFailure";
+
     private static final String DELIVERY_PAUSE = "deliveryPause";
 
     private static final String CASSANDRA_USER = "cassandraUser";
@@ -352,6 +354,8 @@ public class SmscPropertiesManagement implements SmscPropertiesManagementMBean {
     private int diameterDestPort = 3868;
     // Diameter UserName for connection to OCS
     private String diameterUserName = "";
+
+    private boolean markTimeoutAsPermanentFailure = false;
 
     // Days after which old cassandra live tables will be removed
     // min value is 3 days (this means at least 2 days before today tables must be alive),
@@ -1692,6 +1696,17 @@ public class SmscPropertiesManagement implements SmscPropertiesManagementMBean {
         return this.smDeliveryFailureDlrWithTpdu;
     }
 
+    @Override
+    public boolean isMarkTimeoutAsPermanentFailure() {
+        return markTimeoutAsPermanentFailure;
+    }
+
+    @Override
+    public void setMarkTimeoutAsPermanentFailure(boolean markTimeoutAsPermanentFailure) {
+        this.markTimeoutAsPermanentFailure = markTimeoutAsPermanentFailure;
+        this.store();
+    }
+
     public void start() throws Exception {
 
         this.persistFile.clear();
@@ -1771,6 +1786,7 @@ public class SmscPropertiesManagement implements SmscPropertiesManagementMBean {
             writer.write(this.fetchMaxRows, FETCH_MAX_ROWS, Integer.class);
 
             writer.write(this.deliveryPause, DELIVERY_PAUSE, Boolean.class);
+            writer.write(this.markTimeoutAsPermanentFailure, MARK_TIMEOUT_AS_PERMANENT_FAILURE, Boolean.class);
 
             writer.write(this.removingLiveTablesDays, REMOVING_LIVE_TABLES_DAYS, Integer.class);
             writer.write(this.removingArchiveTablesDays, REMOVING_ARCHIVE_TABLES_DAYS, Integer.class);
@@ -2269,6 +2285,10 @@ public class SmscPropertiesManagement implements SmscPropertiesManagementMBean {
                 this.diameterDestPort = val;
 
             this.diameterUserName = reader.read(DIAMETER_USER_NAME, String.class);
+
+            valB = reader.read(MARK_TIMEOUT_AS_PERMANENT_FAILURE, Boolean.class);
+            if (valB != null)
+                this.markTimeoutAsPermanentFailure = valB;
 
             reader.close();
         } catch (XMLStreamException ex) {

--- a/core/domain/src/main/java/org/mobicents/smsc/domain/SmscPropertiesManagementMBean.java
+++ b/core/domain/src/main/java/org/mobicents/smsc/domain/SmscPropertiesManagementMBean.java
@@ -466,4 +466,7 @@ public interface SmscPropertiesManagementMBean {
 
     public Map<Integer, PermanentTemporaryFailure> getSmDeliveryFailureTpCause();
 
+    public boolean isMarkTimeoutAsPermanentFailure();
+
+    public void setMarkTimeoutAsPermanentFailure(boolean markTimeoutAsPermanentFailure);
 }

--- a/core/domain/src/test/java/org/mobicents/smsc/domain/SMSCShellExecutorTest.java
+++ b/core/domain/src/test/java/org/mobicents/smsc/domain/SMSCShellExecutorTest.java
@@ -22,17 +22,21 @@
 
 package org.mobicents.smsc.domain;
 
-import static org.testng.Assert.*;
-
-import javax.slee.facilities.FacilityException;
-import javax.slee.facilities.TraceLevel;
-
-import org.mobicents.smsc.domain.SMSCShellExecutor;
 import org.mobicents.smsc.mproc.OrigType;
 import org.mobicents.smsc.mproc.impl.MProcRuleDefaultImpl;
 import org.mobicents.smsc.mproc.impl.MProcRuleFactoryDefault;
 import org.restcomm.smpp.SmppManagement;
 import org.testng.annotations.Test;
+
+import javax.slee.facilities.FacilityException;
+import javax.slee.facilities.TraceLevel;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  *
@@ -40,6 +44,137 @@ import org.testng.annotations.Test;
  *
  */
 public class SMSCShellExecutorTest {
+
+    private static final String EXPECTED_GET_PROPERTIES_LIST = "scgt = networkId=0 - GT=0\n" +
+            "scssn = -1\n" +
+            "hlrssn = -1\n" +
+            "mscssn = -1\n" +
+            "maxmapv = 3\n" +
+            "gti = 0100\n" +
+            "tt = 0\n" +
+            "defaultvalidityperiodhours = 72\n" +
+            "maxvalidityperiodhours = 240\n" +
+            "defaultton = 1\n" +
+            "defaultnpi = 1\n" +
+            "subscriberbusyduedelay = 120\n" +
+            "firstduedelay = 20\n" +
+            "secondduedelay = 300\n" +
+            "maxduedelay = 86400\n" +
+            "duedelaymultiplicator = 200\n" +
+            "maxmessagelengthreducer = 6\n" +
+            "smppencodingforgsm7 = Utf8\n" +
+            "smppencodingforucs2 = Utf8\n" +
+            "dbhosts = 127.0.0.1\n" +
+            "dbport = 9042\n" +
+            "keyspaceName = RestCommSMSC\n" +
+            "clustername = RestCommSMSC\n" +
+            "fetchperiod = 200\n" +
+            "fetchmaxrows = 100\n" +
+            "maxactivitycount = 500\n" +
+            "deliverytimeout = 120\n" +
+            "deliverytimeoutdeltapermessage = 1\n" +
+            "vpprolong = 120\n" +
+            "esmedefaultcluster = null\n" +
+            "correlationidlivetime = 60\n" +
+            "sriresponselivetime = 0\n" +
+            "revisesecondsonsmscstart = 60\n" +
+            "processingsmssettimeout = 600\n" +
+            "generatereceiptcdr = false\n" +
+            "generatetempfailurecdr = true\n" +
+            "calculatemsgpartslencdr = false\n" +
+            "delayparametersincdr = false\n" +
+            "receiptsdisabling = false\n" +
+            "enableintermediatereceipts = false\n" +
+            "incomereceiptsprocessing = false\n" +
+            "orignetworkidforreceipts = false\n" +
+            "generatecdr = 7\n" +
+            "generatearchivetable = 7\n" +
+            "storeandforwordmode = fast\n" +
+            "mocharging = accept\n" +
+            "hrcharging = accept\n" +
+            "txsmppcharging = None\n" +
+            "txsipcharging = None\n" +
+            "txhttpcharging = accept\n" +
+            "diameterdestrealm = telestax.com\n" +
+            "diameterdesthost = 127.0.0.1\n" +
+            "diameterdestport = 3868\n" +
+            "diameterusername = \n" +
+            "removinglivetablesdays = 3\n" +
+            "removingarchivetablesdays = 3\n" +
+            "hrhlrnumber = networkId=0 - hrhlrnumber=\n" +
+            "hrsribypass = networkId=0 - hrsribypass=false\n" +
+            "nationallanguagesingleshift = 0\n" +
+            "nationallanguagelockingshift = 0\n" +
+            "httpdefaultsourceton = -2\n" +
+            "httpdefaultsourcenpi = -2\n" +
+            "httpdefaultdestton = 1\n" +
+            "httpdefaultdestnpi = 1\n" +
+            "httpdefaultnetworkid = 0\n" +
+            "httpdefaultmessagingmode = 1\n" +
+            "modefaultmessagingmode = 3\n" +
+            "hrdefaultmessagingmode = 3\n" +
+            "sipdefaultmessagingmode = 3\n" +
+            "httpdefaultrddeliveryreceipt = 0\n" +
+            "httpdefaultrdintermediatenotification = 0\n" +
+            "httpdefaultdatacoding = 0\n" +
+            "httpencodingforgsm7 = Utf8\n" +
+            "httpencodingforucs2 = Utf8\n" +
+            "minmessageid = 1\n" +
+            "maxmessageid = 10000000000\n" +
+            "deliverypause = false\n" +
+            "cassandrauser = cassandra\n" +
+            "cassandrapass = cassandra\n" +
+            "smdeliveryfailure_dlr_withtpuserdata = false\n" +
+            "markTimeoutAsPermanentFailure = false";
+
+    @Test(groups = { "ShellExecutor" })
+    public void testShellExecutor_get() throws Exception {
+        SmscManagement smscManagement = SmscManagement.getInstance("Test");
+        SMSCShellExecutor exec = new SMSCShellExecutor();
+        exec.setSmscManagement(smscManagement);
+        exec.start();
+
+        String[] args = new String[2];
+        args[0] = "smsc";
+        args[1] = "get";
+        final String actualResult = exec.execute(args);
+        assertEquals(actualResult.trim(), EXPECTED_GET_PROPERTIES_LIST);
+    }
+
+    @Test(groups = { "ShellExecutor" })
+    public void testShellExecutor_getIndividualProperty() throws Exception {
+        SmscManagement smscManagement = SmscManagement.getInstance("Test");
+        SMSCShellExecutor exec = new SMSCShellExecutor();
+        exec.setSmscManagement(smscManagement);
+        exec.start();
+
+        final List<String> propertyNames = listProperties();
+        for (String propertyName : propertyNames) {
+            String[] args = new String[3];
+            args[0] = "smsc";
+            args[1] = "get";
+            args[2] = propertyName;
+            final String actualResult = exec.execute(args);
+            assertEquals(actualResult.trim(), findExpectedLine(propertyName));
+        }
+    }
+
+    private String findExpectedLine(String propertyName) throws Exception {
+        for (String line : EXPECTED_GET_PROPERTIES_LIST.split("\n")) {
+            if (line.contains(propertyName)) {
+                return line.trim();
+            }
+        }
+        throw new Exception("No line for '" + propertyName + "' found");
+    }
+
+    private List<String> listProperties() {
+        List<String> res = new ArrayList<>();
+        for (String line : EXPECTED_GET_PROPERTIES_LIST.split("\n")) {
+            res.add(line.split("=")[0].trim());
+        }
+        return res;
+    }
 
     @Test(groups = { "ShellExecutor" })
     public void testShellExecutor_DatabaseRoutingRules() throws Exception {

--- a/core/slee/services/sbbs/src/main/java/org/mobicents/smsc/slee/services/mt/MtCommonSbb.java
+++ b/core/slee/services/sbbs/src/main/java/org/mobicents/smsc/slee/services/mt/MtCommonSbb.java
@@ -365,11 +365,12 @@ public abstract class MtCommonSbb extends DeliveryCommonSbb implements Sbb, Repo
 
 	@Override
     protected void onDeliveryTimeout(SmsSet smsSet, String reason) {
-        this.onDeliveryError(smsSet, ErrorAction.temporaryFailure, ErrorCode.SC_SYSTEM_ERROR, reason, true, null, false,
+        ErrorAction failureType = smscPropertiesManagement.isMarkTimeoutAsPermanentFailure() ? ErrorAction.permanentFailure : ErrorAction.temporaryFailure;
+        this.onDeliveryError(smsSet, failureType, ErrorCode.SC_SYSTEM_ERROR, reason, true, null, false,
                 ProcessingType.SS7_MT);
     }
-	
-	@Override
+
+    @Override
     protected Integer getMaxMessagesPerStep() {
         return null;
     }
@@ -642,9 +643,9 @@ public abstract class MtCommonSbb extends DeliveryCommonSbb implements Sbb, Repo
 
     /**
      * TODO: This should be configurable and static as well
-     * 
+     *
      * This is our (Service Center) SCCP Address for GT
-     * 
+     *
      * @return
      */
     protected SccpAddress getServiceCenterSccpAddress(int networkId) {
@@ -672,7 +673,7 @@ public abstract class MtCommonSbb extends DeliveryCommonSbb implements Sbb, Repo
                 mtLocalSccpGt = smscPropertiesManagement.getServiceCenterGt(networkId);
             }
         }
-        
+
         return MessageUtil.getSccpAddress(sccpParameterFact, mtLocalSccpGt, AddressNature.international_number.getIndicator(), NumberingPlan.ISDN.getIndicator(),
                 smscPropertiesManagement.getServiceCenterSsn(), smscPropertiesManagement.getGlobalTitleIndicator(), smscPropertiesManagement.getTranslationType());
     }
@@ -685,7 +686,7 @@ public abstract class MtCommonSbb extends DeliveryCommonSbb implements Sbb, Repo
     protected SccpAddress convertAddressFieldToSCCPAddress(String address, int ton, int npi) {
         return convertAddressFieldToSCCPAddress(address, ton, npi, null);
     }
-    
+
     protected SccpAddress convertAddressFieldToSCCPAddress(String address, int ton, int npi, Integer mtRemoteSccpTt) {
         return MessageUtil.getSccpAddress(sccpParameterFact, address, ton, npi, smscPropertiesManagement.getHlrSsn(),
                 smscPropertiesManagement.getGlobalTitleIndicator(), mtRemoteSccpTt != null ? mtRemoteSccpTt 

--- a/core/slee/services/sbbs/src/main/java/org/mobicents/smsc/slee/services/mt/MtSbb.java
+++ b/core/slee/services/sbbs/src/main/java/org/mobicents/smsc/slee/services/mt/MtSbb.java
@@ -592,7 +592,8 @@ public abstract class MtSbb extends MtCommonSbb implements MtForwardSmsInterface
                 return;
             }
 
-			this.onDeliveryError(smsSet, ErrorAction.temporaryFailure, ErrorCode.MSC_REFUSES_SM,
+			ErrorAction timeoutFailureType = smscPropertiesManagement.isMarkTimeoutAsPermanentFailure() ? ErrorAction.permanentFailure : ErrorAction.temporaryFailure;
+			this.onDeliveryError(smsSet, timeoutFailureType, ErrorCode.MSC_REFUSES_SM,
 					"onDialogTimeout after MtForwardSM Request", true, null, false, ProcessingType.SS7_MT);
 		} catch (Throwable e1) {
 			logger.severe(

--- a/core/slee/services/sbbs/src/main/java/org/mobicents/smsc/slee/services/mt/SriSbb.java
+++ b/core/slee/services/sbbs/src/main/java/org/mobicents/smsc/slee/services/mt/SriSbb.java
@@ -430,7 +430,8 @@ public abstract class SriSbb extends MtCommonSbb implements ReportSMDeliveryStat
                 return;
             }
 
-            this.onDeliveryError(smsSet, ErrorAction.temporaryFailure, ErrorCode.HLR_REJECT_AFTER_ROUTING_INFO,
+            ErrorAction timeoutFailureType = smscPropertiesManagement.isMarkTimeoutAsPermanentFailure() ? ErrorAction.permanentFailure : ErrorAction.temporaryFailure;
+            this.onDeliveryError(smsSet, timeoutFailureType, ErrorCode.HLR_REJECT_AFTER_ROUTING_INFO,
                     "onDialogTimeout after SRI Request", true, null, false, ProcessingType.SS7_SRI);
         } catch (Throwable e1) {
             logger.severe("Exception in SriSbb.onDialogTimeout() when fetching records and issuing events: " + e1.getMessage(), e1);

--- a/core/slee/services/sbbs/src/main/java/org/mobicents/smsc/slee/services/sip/server/rx/RxSipServerSbb.java
+++ b/core/slee/services/sbbs/src/main/java/org/mobicents/smsc/slee/services/sip/server/rx/RxSipServerSbb.java
@@ -347,7 +347,8 @@ public abstract class RxSipServerSbb extends DeliveryCommonSbb implements Sbb {
             return;
         }
 
-		this.onDeliveryError(smsSet, ErrorAction.temporaryFailure, ErrorCode.SC_SYSTEM_ERROR,
+        ErrorAction timeoutFailureType = smscPropertiesManagement.isMarkTimeoutAsPermanentFailure() ? ErrorAction.permanentFailure : ErrorAction.temporaryFailure;
+		this.onDeliveryError(smsSet, timeoutFailureType, ErrorCode.SC_SYSTEM_ERROR,
 				"SIP Exception TRANSACTION_TIMEOUT received.");
 	}
 
@@ -508,7 +509,8 @@ public abstract class RxSipServerSbb extends DeliveryCommonSbb implements Sbb {
 
     @Override
     protected void onDeliveryTimeout(SmsSet smsSet, String reason) {
-        this.onDeliveryError(smsSet, ErrorAction.temporaryFailure, ErrorCode.SC_SYSTEM_ERROR, reason);
+        ErrorAction failureType = smscPropertiesManagement.isMarkTimeoutAsPermanentFailure() ? ErrorAction.permanentFailure : ErrorAction.temporaryFailure;
+        this.onDeliveryError(smsSet, failureType, ErrorCode.SC_SYSTEM_ERROR, reason);
     }
     
     @Override

--- a/core/slee/services/sbbs/src/main/java/org/mobicents/smsc/slee/services/smpp/server/rx/RxSmppServerSbb.java
+++ b/core/slee/services/sbbs/src/main/java/org/mobicents/smsc/slee/services/smpp/server/rx/RxSmppServerSbb.java
@@ -420,7 +420,8 @@ public abstract class RxSmppServerSbb extends DeliveryCommonSbb implements Sbb {
             logger.severe(
                     String.format("onPduRequestTimeout : targetId=" + smsSet.getTargetId() + ", PduRequestTimeout=" + event));
 
-            this.onDeliveryError(smsSet, ErrorAction.temporaryFailure, ErrorCode.SC_SYSTEM_ERROR, "PduRequestTimeout: ",
+            ErrorAction timeoutFailureType = smscPropertiesManagement.isMarkTimeoutAsPermanentFailure() ? ErrorAction.permanentFailure : ErrorAction.temporaryFailure;
+            this.onDeliveryError(smsSet, timeoutFailureType, ErrorCode.SC_SYSTEM_ERROR, "PduRequestTimeout: ",
                     EventType.OUT_SMPP_ERROR, event.getPduRequest().getSequenceNumber());
         } catch (Throwable e1) {
             anSbbUsage.incrementCounterErrorPduRequestTimeoutParent(ONE);
@@ -989,7 +990,8 @@ public abstract class RxSmppServerSbb extends DeliveryCommonSbb implements Sbb {
      */
     @Override
     protected void onDeliveryTimeout(SmsSet smsSet, String reason) {
-        this.onDeliveryError(smsSet, ErrorAction.temporaryFailure, ErrorCode.SC_SYSTEM_ERROR, reason,
+        ErrorAction timeoutFailureType = smscPropertiesManagement.isMarkTimeoutAsPermanentFailure() ? ErrorAction.permanentFailure : ErrorAction.temporaryFailure;
+        this.onDeliveryError(smsSet, timeoutFailureType, ErrorCode.SC_SYSTEM_ERROR, reason,
                 EventType.OUT_SMPP_TIMEOUT, -1);
     }
 


### PR DESCRIPTION
refactored SMSCShellExecutor:removed duplicates for CLI get command;
added new option to CLI get command;
added tests for CLI get command;
added new flag 'markTimeoutAsPermanentFailure' to SmscPropertiesManagement;
added functionality for new flag;
Fixes #289 

reduced code in ShellExecutor;
added discovery of new getters via reflection:
 no need to add manual call of getter method, getter will be discovered automatically
```java
    private void initSmscPropertiesManagementGetters() {
        smscPropertiesManagementGetters = new HashMap<>();
        Class c = smscPropertiesManagement.getClass();
        for (Method method : c.getMethods()) {
            String methodName = method.getName();
            if (methodName.startsWith("get")) {
                smscPropertiesManagementGetters.put(methodName.substring(3).toLowerCase(), method);
            } else if (methodName.startsWith("is")) {
                smscPropertiesManagementGetters.put(methodName.substring(2).toLowerCase(), method);
            }
        }
    }
```

then just call function 
`addProperty(sb, "${getterNameWithout_get|is}");`